### PR TITLE
# Remove dependency on outdated webdrivers gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ## Changed
 * Drop support for Ruby 2.7, Rails 6.0
+* Remove dependency on outdated `webdrivers` gem
 
 ## 7.1.0 / 2023-03-02
 ### Fixed

--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -21,10 +21,6 @@ require 'ndr_dev_support/integration_testing/dsl'
 # Include support for retrying tests that sporadically fail:
 require 'ndr_dev_support/integration_testing/flakey_tests'
 
-# Keeps the selenium webdrivers automatically updated:
-require 'webdrivers'
-Webdrivers.cache_time = 24.hours
-
 # These are all the drivers we have capybara / screenshot support for:
 require 'ndr_dev_support/integration_testing/drivers/chrome'
 require 'ndr_dev_support/integration_testing/drivers/chrome_headless'

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome_headless.rb
@@ -12,6 +12,11 @@ Capybara.register_driver :chrome_headless do |app|
     opts.args << '--window-size=1920,1080'
     opts.args << '--enable-features=NetworkService,NetworkServiceInProcess'
   end
+  # Hide messages such as the following:
+  # WARN Selenium [:logger_info] Details on how to use and modify Selenium logger:
+  #   https://selenium.dev/documentation/webdriver/troubleshooting/logging#ruby
+  Selenium::WebDriver.logger.ignore([:logger_info])
+
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -37,9 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capybara', '>= 3.34'
   spec.add_dependency 'capybara-screenshot'
   spec.add_dependency 'minitest', '~> 5.11'
-  spec.add_dependency 'selenium-webdriver'
+  spec.add_dependency 'selenium-webdriver', '~> 4.8'
   spec.add_dependency 'show_me_the_cookies'
-  spec.add_dependency 'webdrivers', '>= 3.9'
 
   # CI server dependencies:
   spec.add_dependency 'activesupport', '>= 6.1', '< 7.1'


### PR DESCRIPTION
Remove requirement for `webdrivers` gem. This should no longer be needed with recent `selenium-webdriver` versions, cf. https://github.com/titusfortner/webdrivers/issues/247