### PR TITLE
Minitest fixes and updates to branch names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+## Changed
+* Use feature/ branch names for rake bundle:update
+
 ### Fixed
 * Fix outdated MiniTest reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* No unreleased changes
+### Fixed
+* Fix outdated MiniTest reference
 
 ## 7.2.0 / 2023-07-20
 ## Changed

--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -8,7 +8,7 @@ ActionDispatch::IntegrationTest.include(Capybara::DSL)
 #       use the built-in behaviour that Rails adds to after_teardown.
 #
 require 'capybara-screenshot'
-if defined?(MiniTest)
+if defined?(Minitest)
   require 'capybara-screenshot/minitest'
   ActionDispatch::IntegrationTest.include(Capybara::Screenshot::MiniTestPlugin)
 else

--- a/lib/tasks/audit_bundle.rake
+++ b/lib/tasks/audit_bundle.rake
@@ -195,7 +195,7 @@ namespace :bundle do
 
     if repository_type == 'git'
       # Check out a fresh branch, if a git working copy (but not git-svn)
-      branch_name = "#{gem}_#{new_gem_version2.gsub('.', '_')}"
+      branch_name = "feature/#{gem}_#{new_gem_version2.gsub('.', '_')}"
       system('git', 'checkout', '-b', branch_name) # Create a new git branch
     end
 


### PR DESCRIPTION
This fixes an issue when `minitest` 5.19.0 is used with `ndr_dev_support`, similar to https://github.com/freerange/mocha/issues/614

It also updates branch names used in `rake bundle:update gem=...` to start with `feature/`