### PR TITLE
Convenience updates for rake bundle:update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 * Support Rails 7.1
+* Convenience updates for rake bundle:update
 
 ## 7.2.1 / 2023-09-04
 ## Changed

--- a/lib/tasks/audit_bundle.rake
+++ b/lib/tasks/audit_bundle.rake
@@ -204,9 +204,10 @@ namespace :bundle do
       manually add any additional platform-specific gems required (e.g. for nokogiri),
       re-run tests locally, then run the following to commit the changes:
 
-      $ git rm #{files_to_git_rm.join(' ')}
-      $ git add #{files_to_git_add.join(' ')}
-      $ git commit -m '# Bump #{gem} to #{new_gem_version2}'
+      $ ( git rm #{files_to_git_rm.join(' ')}
+          git add #{files_to_git_add.join(' ')}
+          git commit -m '# Bump #{gem} to #{new_gem_version2}'
+        )
     MSG
   end
 end


### PR DESCRIPTION
This makes it easier to copy and paste the output from `rake bundle:update` into a terminal window.