### PR TITLE
Change default browser for integration tests to new headless Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
-*no unreleased changes*
+## Changed
+* Change default browser for integration tests to new headless Chrome
+* Support old chrome headless driver
 
 ## 7.2.3 / 2023-12-08
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ require 'ndr_dev_support/integration_testing'
 
 #### Other drivers
 
-Other drivers are also supported; `chrome` / `chrome_headless` / `firefox` are all powered by selenium, and can either be explicitly used with:
+Other drivers are also supported; `chrome` / `chrome_headless` / `chrome_headless_old` / `firefox` are all powered by selenium, and can either be explicitly used with:
 
 ```ruby
 Capybara.default_driver    = :chrome_headless

--- a/lib/ndr_dev_support/integration_testing.rb
+++ b/lib/ndr_dev_support/integration_testing.rb
@@ -24,6 +24,7 @@ require 'ndr_dev_support/integration_testing/flakey_tests'
 # These are all the drivers we have capybara / screenshot support for:
 require 'ndr_dev_support/integration_testing/drivers/chrome'
 require 'ndr_dev_support/integration_testing/drivers/chrome_headless'
+require 'ndr_dev_support/integration_testing/drivers/chrome_headless_old'
 require 'ndr_dev_support/integration_testing/drivers/firefox'
 require 'ndr_dev_support/integration_testing/drivers/switchable'
 

--- a/lib/ndr_dev_support/integration_testing/drivers/chrome_headless_old.rb
+++ b/lib/ndr_dev_support/integration_testing/drivers/chrome_headless_old.rb
@@ -1,10 +1,11 @@
 require 'selenium-webdriver'
 require 'show_me_the_cookies'
 
-Capybara.register_driver :chrome_headless do |app|
+# Use the old chrome headless driver
+Capybara.register_driver :chrome_headless_old do |app|
   Capybara::Selenium::Driver.load_selenium
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    opts.args << '--headless=new'
+  browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    opts.args << '--headless'
     opts.args << '--disable-gpu' if Gem.win_platform?
     opts.args << '--no-sandbox'
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
@@ -20,8 +21,8 @@ Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
-Capybara::Screenshot.register_driver(:chrome_headless) do |driver, path|
+Capybara::Screenshot.register_driver(:chrome_headless_old) do |driver, path|
   driver.browser.save_screenshot(path)
 end
 
-ShowMeTheCookies.register_adapter(:chrome_headless, ShowMeTheCookies::SeleniumChrome)
+ShowMeTheCookies.register_adapter(:chrome_headless_old, ShowMeTheCookies::SeleniumChrome)


### PR DESCRIPTION
This PR changes the default browser for integration tests to the new chrome headless browser. The old chrome headless driver can still be accessed as `:chrome_headless_old` cf. https://www.selenium.dev/blog/2023/headless-is-going-away/