### PR TITLE
Reduce the number of releases kept on application servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Changed
 * Change default browser for integration tests to new headless Chrome
 * Support old chrome headless driver
+* Reduce the number of releases kept on application servers
 
 ## 7.2.3 / 2023-12-08
 ### Fixed

--- a/lib/ndr_dev_support/capistrano/ndr_model.rb
+++ b/lib/ndr_dev_support/capistrano/ndr_model.rb
@@ -116,6 +116,9 @@ Capistrano::Configuration.instance(:must_exist).load do
       # Where we'll be deploying to:
       set :deploy_to, File.join(application_home, fetch(:application))
 
+      # Reduce the number of releases we keep on the webapp servers
+      set :keep_releases, 3 unless exists?(:keep_releases) || fetch(:daemon_deployment)
+
       # Use the application user's ruby:
       set(:default_environment) do
         {


### PR DESCRIPTION
Reduce the default number of releases we keep on webapp servers to 3 (previously 5).

This does not change the number of releases we keep on daemon servers (default 5 unless overridden): we have much longer lived processes there, and I think there's more risk there of removing the filesystem under running code, e.g. when we have batch tasks that run for many hours and we do a number of beta redeployments on the same day.

This should help a little with our storage issues on various webapp servers.