### PR TITLE
Capistrano: fix up installed gem permissions after deployment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+* Capistrano: fix up installed gem permissions after deployment.
+* Capistrano: identify errors when installing out-of-bundle gems.
 
 ## 7.2.4 / 2024-05-01
 ## Changed

--- a/lib/ndr_dev_support/capistrano/standalone_gems.rb
+++ b/lib/ndr_dev_support/capistrano/standalone_gems.rb
@@ -24,12 +24,13 @@ Capistrano::Configuration.instance(:must_exist).load do
       # Extract the current version requirements for each of the gems from the lockfile,
       # and then check they're installed. If not, install them from the vendored cache.
       run <<~CMD if gem_list.any?
+        set -e;
         export RBENV_VERSION=`cat "#{latest_release}/.ruby-version"`;
         cat "#{latest_release}/Gemfile.lock" | egrep "^    (#{gem_list.join('|')}) " | tr -d '()' | \
         while read gem ver; do
           gem list -i "$gem" --version "$ver" > /dev/null || \
           #{gem_install} "#{latest_release}/vendor/cache/$gem-$ver.gem" \
-            --ignore-dependencies --conservative --no-document;
+            --ignore-dependencies --conservative --no-document --local;
         done
       CMD
     end


### PR DESCRIPTION
Capistrano: fix up installed gem permissions after deployment.

This fixes permissions in the `shared/bundle/` directory after deployment, to make it writeable by all deployers. We already set group permissions correctly in the `bundle` directory, but some gem installs ignore these permissions, so we need to fix them up. (I think they build files in `$TMPDIR`, and then move them across with the wrong group / user.) This is not immediately obvious as a problem, but sometimes makes it impossible for a single deployer to remove the installed gems for old ruby versions.

Capistrano: identify errors when installing out-of-bundle gems.
