### PR TITLE
Allow either EnforcedShorthandSyntax Hash style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 * Capistrano: fix up installed gem permissions after deployment.
 * Capistrano: identify errors when installing out-of-bundle gems.
+* Allow either hash `EnforcedShorthandSyntax` style
 
 ## 7.2.4 / 2024-05-01
 ## Changed

--- a/config/rubocop/ndr.yml
+++ b/config/rubocop/ndr.yml
@@ -145,3 +145,5 @@ Rails/SkipsModelValidations:
   # avoiding them is not helpful/practical.
   Enabled: false
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either


### PR DESCRIPTION
Allow either EnforcedShorthandSyntax Hash style

Tested locally by pointing another codebase at this branch and running `bin/rake rubocop:diff develop` with known code that triggered the `EnforcedShorthandSyntax` cop previously.