### PR TITLE
tag v7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+*no unreleased changes*
+
+## 7.3.0 / 2024-12-19
 ### Added
 * Capistrano: install rbenv and ruby from /opt/rbenv.tar.gz or vendor/rbenv/
 

--- a/lib/ndr_dev_support/version.rb
+++ b/lib/ndr_dev_support/version.rb
@@ -2,5 +2,5 @@
 # This defines the NdrDevSupport version. If you change it, rebuild and commit the gem.
 # Use "rake build" to build the gem, see rake -T for all bundler rake tasks (and our own).
 module NdrDevSupport
-  VERSION = '7.2.6'
+  VERSION = '7.3.0'
 end


### PR DESCRIPTION
This is a minor release, because it should continue to work for our CentOS and Amazon Linux 2023 deployments: I've tested it for the `era` and `api_upload_portal` repositories.