### PR TITLE
tag v7.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+*no unreleased changes*
+
+## 7.3.1 / 2025-01-02
 ### Added
 * Capistrano: deploy application secrets from a subversion or git repository
 

--- a/code_safety.yml
+++ b/code_safety.yml
@@ -27,7 +27,7 @@ file safety:
   CHANGELOG.md:
     comments:
     reviewed_by: brian.shand
-    safe_revision: 71036ef8c1a1d040281c692868246e6ab7a6ba37
+    safe_revision: f15b2f95bdb7252b9bf60eee65e69207ce486e9d
   CODE_OF_CONDUCT.md:
     comments:
     reviewed_by: timgentry
@@ -96,6 +96,10 @@ file safety:
     comments:
     reviewed_by: brian.shand
     safe_revision: 71036ef8c1a1d040281c692868246e6ab7a6ba37
+  lib/ndr_dev_support/capistrano/deploy_secrets.rb:
+    comments:
+    reviewed_by: brian.shand
+    safe_revision: f15b2f95bdb7252b9bf60eee65e69207ce486e9d
   lib/ndr_dev_support/capistrano/install_ruby.rb:
     comments:
     reviewed_by: brian.shand
@@ -103,7 +107,7 @@ file safety:
   lib/ndr_dev_support/capistrano/ndr_model.rb:
     comments:
     reviewed_by: brian.shand
-    safe_revision: 71036ef8c1a1d040281c692868246e6ab7a6ba37
+    safe_revision: f15b2f95bdb7252b9bf60eee65e69207ce486e9d
   lib/ndr_dev_support/capistrano/restart.rb:
     comments:
     reviewed_by: josh.pencheon
@@ -243,7 +247,7 @@ file safety:
   lib/ndr_dev_support/version.rb:
     comments:
     reviewed_by: brian.shand
-    safe_revision: 601cb39a50fd3b719083fed23bf1cb9ae512d223
+    safe_revision: e1b6dbf71344f982a4238e3e8085d533f7c51d06
   lib/tasks/audit_bundle.rake:
     comments:
     reviewed_by: kenny.lee

--- a/lib/ndr_dev_support/version.rb
+++ b/lib/ndr_dev_support/version.rb
@@ -2,5 +2,5 @@
 # This defines the NdrDevSupport version. If you change it, rebuild and commit the gem.
 # Use "rake build" to build the gem, see rake -T for all bundler rake tasks (and our own).
 module NdrDevSupport
-  VERSION = '7.3.0'
+  VERSION = '7.3.1'
 end


### PR DESCRIPTION
This is a patch release: it adds support for deploying application secrets, but this is opt-in behaviour which does nothing unless explicitly triggered.