### PR TITLE
Add missing library required by ndr_dev_support:deploy_secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Capistrano: Add missing `tmpdir` requirement to deploy application secrets
 
 ## 7.3.1 / 2025-01-02
 ### Added

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'activesupport', '~> 6.1.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'activesupport', '~> 7.0.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/lib/ndr_dev_support/capistrano/deploy_secrets.rb
+++ b/lib/ndr_dev_support/capistrano/deploy_secrets.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 # Add a git or svn secrets respository for ndr_dev_support:deploy_secrets
 def add_secrets_repo(name:, url:, scm:, branch: nil)
   raise "Invalid repo name #{name}" unless /\A[A-Z0-9_-]+\z/i.match?(name)


### PR DESCRIPTION
This PR adds a missing ruby `require` for `ndr_dev_support:deploy_secrets`.

Workaround: without this, applications using this feature need to `require 'tmpdir'` in their `config/deploy.rb`.

We don't have a test harness for capistrano tasks, which is why this wasn't identified in testing. I've tested this by fixing the gem locally, and confirming that the extra `require` is no longer needed.