### PR TITLE
Update rubocop version dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Update rubocop version dependency
 
 ## 7.3.2 / 2025-05-01
 ### Fixed

--- a/ndr_dev_support.gemspec
+++ b/ndr_dev_support.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Rubocop dependencies:
   spec.add_dependency 'parser'
   spec.add_dependency 'rainbow'
-  spec.add_dependency 'rubocop', '~> 1.7'
+  spec.add_dependency 'rubocop', '~> 1.72'
   spec.add_dependency 'rubocop-rails', '~> 2.9'
   spec.add_dependency 'rubocop-rake', '~> 0.5'
   spec.add_dependency 'unicode-display_width', '>= 1.3.3'


### PR DESCRIPTION
Update rubocop gem dependency to ~> 1.72 to support the use of `plugins` instead of `require`.

This is not a critical fix (i.e. we don't need to pull ndr_dev_support 7.3.2), just a convenience.