### PR TITLE
Capistrano should cleanup bundled gems for old ruby versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
     - name: Install dependencies
       run: bundle install
     - name: Run RuboCop against BASE..HEAD changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - '3.1'
@@ -21,6 +22,10 @@ jobs:
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
           - ruby-version: '3.1'
             gemfile: 'gemfiles/Gemfile.rails80'
+          # rails 7.0 requires ruby <= 3.3
+          # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails70'
 
     name: Ruby ${{ matrix.ruby-version }} / Bundle ${{ matrix.gemfile }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
         gemfile:
           - gemfiles/Gemfile.rails70
           - gemfiles/Gemfile.rails71

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Fixed
 * Capistrano: deploy:preinstall should fix up installed gem permissions
+* Support Ruby 3.4
 
 ### Added
 * Capistrano: cleanup bundled gems for old ruby versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-*no unreleased changes*
+### Fixed
+* Capistrano: deploy:preinstall should fix up installed gem permissions
 
 ## 7.3.3 / 2025-07-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Fixed
 * Capistrano: deploy:preinstall should fix up installed gem permissions
 
+### Added
+* Capistrano: cleanup bundled gems for old ruby versions.
+
 ## 7.3.3 / 2025-07-31
 ### Fixed
 * Update rubocop version dependency

--- a/lib/ndr_dev_support/capistrano/ndr_model.rb
+++ b/lib/ndr_dev_support/capistrano/ndr_model.rb
@@ -164,8 +164,12 @@ Capistrano::Configuration.instance(:must_exist).load do
         # already there:
         run "rm -rf #{File.join(release_path, path)} && ln -s #{File.join(shared_path, path)} #{File.join(release_path, path)}"
       end
+    end
 
-      # Make the shared/bundle/ directory writeable by deployers:
+    after 'deploy:finalize_update', 'ndr_dev_support:filesystem_tweaks'
+
+    desc 'Make the shared/bundle/ directory writeable by deployers'
+    task :bundle_permissions do
       # We already set group permissions correctly in the bundle directory, but some gem installs
       # ignore these permissions, so we need to fix them up.
       # Set deployer group for everything created by this user
@@ -178,7 +182,8 @@ Capistrano::Configuration.instance(:must_exist).load do
           '-not -perm -0064 -print0 |xargs -r0 chmod g+rw,o+r'
     end
 
-    after 'deploy:finalize_update', 'ndr_dev_support:filesystem_tweaks'
+    # Ensure we have fixed the bundle permissions before potentially aborting
+    before 'ndr_dev_support:check_preinstall', 'ndr_dev_support:bundle_permissions'
   end
 end
 


### PR DESCRIPTION
Deletes shared bundle files that no longer match any installed releases. For example, if the currently installed releases are all ruby 3.2 and 3.3., this will remove any installed ruby 3.1 gems.

For deployments with long-lived application servers, this limits the space growth of application deployments. There isn't anything yet to remove installed `.rbenv` versions: this is harder, because multiple deployments can share the same user account – possibly inside nested directories.

Capistrano: `deploy:preinstall` should fix up installed gem permissions. (Before this fix, `deploy:preinstall` would abort before fixing up gem permissions.)

Support Ruby 3.4.